### PR TITLE
fix: type annotation issue with python 3.8

### DIFF
--- a/src/obsidian_to_hugo/md_mark_processor.py
+++ b/src/obsidian_to_hugo/md_mark_processor.py
@@ -2,14 +2,14 @@
 Utilities to extract markdown marks from text and turn them into html marks.
 """
 
-from typing import TypedDict
+from typing import TypedDict, List
 import re
 
 
 Mark = TypedDict("Marks", {"md_mark": str, "text": str})
 
 
-def get_md_marks(text: str) -> list[Mark]:
+def get_md_marks(text: str) -> List[Mark]:
     """
     Get all markdown marks from the given text and return a list of them.
     Each list item is a dictionary with the following keys:

--- a/src/obsidian_to_hugo/wiki_links_processor.py
+++ b/src/obsidian_to_hugo/wiki_links_processor.py
@@ -2,14 +2,14 @@
 Utilities to extract wiki links from text and turn them into hugo links.
 """
 
-from typing import TypedDict
+from typing import TypedDict, List
 import re
 
 
 WikiLink = TypedDict("WikiLink", {"wiki_link": str, "link": str, "text": str})
 
 
-def get_wiki_links(text: str) -> list[WikiLink]:
+def get_wiki_links(text: str) -> List[WikiLink]:
     """
     Get all wiki links from the given text and return a list of them.
     Each list item is a dictionary with the following keys:


### PR DESCRIPTION
When running `python -m obsidian_to_hugo --version` from an appropriate venv this is returned:

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 185, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.8/runpy.py", line 144, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "/usr/lib/python3.8/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "/home/sion/Toybox/docs.int/venv/lib/python3.8/site-packages/obsidian_to_hugo/__init__.py", line 1, in <module>
    from .obsidian_to_hugo import ObsidianToHugo
  File "/home/sion/Toybox/docs.int/venv/lib/python3.8/site-packages/obsidian_to_hugo/obsidian_to_hugo.py", line 8, in <module>
    from .wiki_links_processor import replace_wiki_links
  File "/home/sion/Toybox/docs.int/venv/lib/python3.8/site-packages/obsidian_to_hugo/wiki_links_processor.py", line 12, in <module>
    def get_wiki_links(text: str) -> list[WikiLink]:
TypeError: 'type' object is not subscriptable
```

expected result is: `obsidian-to-hugo 0.3.0`

When using version 3.9 the different types are depreciated but as this is targeting any version newer than 3.6 it's neccesary to use the generics.

3.9 will not generate DeprecationWarnings