### PR TITLE
fix wikilink inside markdown table

### DIFF
--- a/src/obsidian_to_hugo/wiki_links_processor.py
+++ b/src/obsidian_to_hugo/wiki_links_processor.py
@@ -24,7 +24,9 @@ def get_wiki_links(text: str) -> List[WikiLink]:
             "wiki_link": match.group(),
         }
 
-        if "|" in match.group(1):
+        if "\|" in match.group(1):
+            out["link"], out["text"] = match.group(1).split("\|")
+        elif "|" in match.group(1):
             out["link"], out["text"] = match.group(1).split("|")
         else:
             out["link"] = match.group(1)

--- a/tests/test_wiki_links_processor.py
+++ b/tests/test_wiki_links_processor.py
@@ -34,6 +34,11 @@ class WikiLinksProcessorTestCase(unittest.TestCase):
         hugo_link = wiki_links_processor.wiki_link_to_hugo_link(wiki_link)
         self.assertEqual(hugo_link, '[baz]({{< ref "bar" >}})')
 
+    def test_convert_wiki_link_with_text_and_backslash(self):
+        wiki_link = wiki_links_processor.get_wiki_links("[[bar\|baz]]")[0]
+        hugo_link = wiki_links_processor.wiki_link_to_hugo_link(wiki_link)
+        self.assertEqual(hugo_link, '[baz]({{< ref "bar" >}})')
+
     def test_convert_wiki_link_with_index(self):
         wiki_link = wiki_links_processor.get_wiki_links("[[bar/_index|baz]]")[0]
         hugo_link = wiki_links_processor.wiki_link_to_hugo_link(wiki_link)
@@ -48,11 +53,13 @@ class WikiLinksProcessorTestCase(unittest.TestCase):
         real_in = """
         [[foo]]
         [[bar|baz]]
+        [[bar\|baz]]
         [[bar/_index|baz]]
         [[bar#Foo Bar|baz]]
         """
         expected_out = """
         [foo]({{< ref "foo" >}})
+        [baz]({{< ref "bar" >}})
         [baz]({{< ref "bar" >}})
         [baz]({{< ref "bar/" >}})
         [baz]({{< ref "bar#foo-bar" >}})


### PR DESCRIPTION
Obsidian require to add backslash \ before pipes | in link that are inside tables, to distinguish pipes for the link and thoses for the table.

Input :
```
columnA|columnB
----|---- 
[[#linkRef\|linkText]] | row B
```

Intended result
```
columnA|columnB
----|----
[linkText]({{< ref "#linkRef" >}}) | rowB
```

Actual result (7d7e7f04dfea3b2bf87f5562f74ffddf23b1a785)
```
columnA|columnB
----|----
[linkText]({{< ref "#linkRef\" >}}) | rowB
```
