### PR TITLE
Image links & CI/CD tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: PR Workflow
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  workflow_dispatch:
+
+
+jobs:
+  tests:
+    name: Tests (python v${{ matrix.python_version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python_version:
+        - "3.9"
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # TODO likely should be done via uv and pyproject.toml
+      - name: Set up Python ${{ matrix.python_version }}
+        uses: actions/setup-python@v4
+        with:
+          python_version: ${{ matrix.python_version }}
+
+      - name: Run tests
+        run: |
+          touch .env # needed for minimal intrusion into the original Makefile
+          make test

--- a/src/obsidian_to_hugo/wiki_links_processor.py
+++ b/src/obsidian_to_hugo/wiki_links_processor.py
@@ -18,7 +18,7 @@ def get_wiki_links(text: str) -> List[WikiLink]:
     - text: the possible extracted text
     """
     wiki_links = []
-    wiki_link_regex = r"\[\[(.*?)\]\]"
+    wiki_link_regex = r"\!?\[\[(.*?)\]\]"
     for match in re.finditer(wiki_link_regex, text):
         out = {
             "wiki_link": match.group(),
@@ -53,7 +53,15 @@ def wiki_link_to_hugo_link(wiki_link: WikiLink) -> str:
         )
     else:
         link_combined = wiki_link["link"]
-    hugo_link = f'[{wiki_link["text"]}]({{{{< ref "{link_combined}" >}}}})'
+
+    # Process image links too
+    if wiki_link["wiki_link"].startswith("!"):
+        # check if the wiki_link has text in a lambda and assign it to caption:
+        caption_tag = f'caption="{wiki_link["text"]}"' if ("text" in wiki_link and wiki_link['text'] != link_combined )  else ""
+        hugo_link = f'{{{{< figure src="{link_combined}" {caption_tag} >}}}}'
+    else:
+        hugo_link = f'[{wiki_link["text"]}]({{{{< ref "{link_combined}" >}}}})'
+
     return hugo_link
 
 

--- a/tests/test_wiki_links_processor.py
+++ b/tests/test_wiki_links_processor.py
@@ -49,6 +49,12 @@ class WikiLinksProcessorTestCase(unittest.TestCase):
         hugo_link = wiki_links_processor.wiki_link_to_hugo_link(wiki_link)
         self.assertEqual(hugo_link, '[baz]({{< ref "bar#foo-bar" >}})')
 
+    def test_convert_wiki_link_with_image_link(self):
+        wiki_link = wiki_links_processor.get_wiki_links("![[../_media/foo-bar.png|foo-bar 🙂]]")[0]
+        hugo_link = wiki_links_processor.wiki_link_to_hugo_link(wiki_link)
+        self.assertEqual(hugo_link, '{{< figure src="../_media/foo-bar.png" caption="foo-bar 🙂" >}}')
+
+
     def test_replace_wiki_links(self):
         real_in = """
         [[foo]]
@@ -56,6 +62,7 @@ class WikiLinksProcessorTestCase(unittest.TestCase):
         [[bar\|baz]]
         [[bar/_index|baz]]
         [[bar#Foo Bar|baz]]
+        ![[../_media/foo-bar.png|foo-bar 🙂]]
         """
         expected_out = """
         [foo]({{< ref "foo" >}})
@@ -63,6 +70,7 @@ class WikiLinksProcessorTestCase(unittest.TestCase):
         [baz]({{< ref "bar" >}})
         [baz]({{< ref "bar/" >}})
         [baz]({{< ref "bar#foo-bar" >}})
+        {{< figure src="../_media/foo-bar.png" caption="foo-bar 🙂" >}}
         """
         real_out = wiki_links_processor.replace_wiki_links(real_in)
         self.assertEqual(real_out, expected_out)


### PR DESCRIPTION
# Description
This PR is a small change that allows to include `![[]]` types of wiki links in the processing (images)


- Add ability to parse image links into Hugo's figure
- Add ability to run tests in CI/CD

# Testing
- Coverage added, [workflow run](https://github.com/AutomationD/obsidian-to-hugo/actions/runs/13767887437) is successful

(supersedes https://github.com/devidw/obsidian-to-hugo/pull/21)