### PR TITLE
Add wiki link escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,6 @@ It takes care of the following steps:
 | `[[/some/wiki/link#Some Heading\|Some Heading Link]]` | `[Some Heading Link]({{< ref "/some/wiki/link#some-heading" >}})`
 | `==foo bar===` | `<mark>foo bar</mark>`
 
-> **Note**
-> For now, there is *no way to escape* obsidian wiki links. Every link
-> will be replaced with a hugo link. The only way to get around this is changing
-> the wiki link to don't match the exact sytax, for example by adding an
-> [invisible space](https://en.wikipedia.org/wiki/Zero-width_space) (Obsidian will highlight the invisible character as a red dot).
-> ![](https://raw.githubusercontent.com/devidw/obsidian-to-hugo/master/img/do-not-do-that.png)
-> However, this still is really really *not* best
-> practice, so if anyone wants to implement real escaping, [please do
-> so](https://github.com/devidw/obsidian-to-hugo/pulls).
-
 
 ## Installation
 

--- a/src/obsidian_to_hugo/wiki_links_processor.py
+++ b/src/obsidian_to_hugo/wiki_links_processor.py
@@ -7,6 +7,7 @@ import re
 
 
 WikiLink = TypedDict("WikiLink", {"wiki_link": str, "link": str, "text": str})
+WIKI_LINK_PATTERN = re.compile(r"(?:^|(?<=[^\\])|(?<=\\\\))\[\[(.*?)\]\]")
 
 
 def get_wiki_links(text: str) -> List[WikiLink]:
@@ -18,8 +19,7 @@ def get_wiki_links(text: str) -> List[WikiLink]:
     - text: the possible extracted text
     """
     wiki_links = []
-    wiki_link_regex = r"\[\[(.*?)\]\]"
-    for match in re.finditer(wiki_link_regex, text):
+    for match in re.finditer(WIKI_LINK_PATTERN, text):
         out = {
             "wiki_link": match.group(),
         }

--- a/tests/test_wiki_links_processor.py
+++ b/tests/test_wiki_links_processor.py
@@ -24,6 +24,59 @@ class WikiLinksProcessorTestCase(unittest.TestCase):
             },
         )
 
+    def test_get_wiki_links_no_space(self):
+        text = "hello[[world]] [[bar|baz]]"
+        links = wiki_links_processor.get_wiki_links(text)
+        self.assertEqual(len(links), 2)
+        self.assertEqual(
+            links[0],
+            {
+                "wiki_link": "[[world]]",
+                "link": "world",
+                "text": "world",
+            },
+        )
+        self.assertEqual(
+            links[1],
+            {
+                "wiki_link": "[[bar|baz]]",
+                "link": "bar",
+                "text": "baz",
+            },
+        )
+
+    def test_get_wiki_link_with_escape(self):
+        wiki_links = wiki_links_processor.get_wiki_links("Hello \\[[world]], [[foo]]")
+        self.assertEqual(len(wiki_links), 1)
+        self.assertEqual(
+            wiki_links[0],
+            {
+                "wiki_link": "[[foo]]",
+                "link": "foo",
+                "text": "foo",
+            },
+        )
+
+    def test_get_wiki_link_with_escaped_backslash(self):
+        wiki_links = wiki_links_processor.get_wiki_links("Hello \\\\[[world]], [[foo]]")
+        self.assertEqual(len(wiki_links), 2)
+        self.assertEqual(
+            wiki_links[0],
+            {
+                "wiki_link": "[[world]]",
+                "link": "world",
+                "text": "world",
+            },
+        )
+        self.assertEqual(
+            wiki_links[1],
+            {
+                "wiki_link": "[[foo]]",
+                "link": "foo",
+                "text": "foo",
+            },
+        )
+
     def test_convert_wiki_link(self):
         wiki_link = wiki_links_processor.get_wiki_links("[[foo]]")[0]
         hugo_link = wiki_links_processor.wiki_link_to_hugo_link(wiki_link)


### PR DESCRIPTION
The changes in this pull request modify the wiki link patterns to skip escaped wiki links. Consistent with Obsidian, wiki links can be escaped with a single backslash `\` character before the first opening bracket, e.g., `\[[escaped]]`. If the opening bracket is preceded by two backslashes, it is not escaped, e.g., `\\[[not escaped]]`. 

This pull request resolves the following issue:

> Note For now, there is no way to escape obsidian wiki links. Every link will be replaced with a hugo link. 

The following regex is added to the wiki link regex: `(?:^|(?<=[^\\])|(?<=\\\\))\[\[(.*?)\]\]`.

- `\[\[(.*?)\]\]`: Wiki link pattern, two opening square brackets, followed by an arbitrary character sequence, end ended by the next two closing square brackets.
- `(?:^|(?<=[^\\])|(?<=\\\\))`: Specifies that to be a valid wiki link, the first opening bracket must be preceded by:
  1. the start of the sequence `^`,
  2. any character that is not backslash, or
  3. two backslashes.